### PR TITLE
Fix issues with arg parsing

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    mojo_magick (0.6.1)
+    mojo_magick (0.6.0)
 
 GEM
   remote: https://rubygems.org/

--- a/README.md
+++ b/README.md
@@ -211,11 +211,11 @@ in the new code
 
 Recent Changes
 ==============
-#### Version 0.6.1
+#### Version 0.6.0
 
 * general cleanup and update gems - ready for ImageMagick 7
 * dumped resource limit handling
-* PR #29
+* PR #29, #30
 
 #### Version 0.5.6
 

--- a/lib/mojo_magick.rb
+++ b/lib/mojo_magick.rb
@@ -68,19 +68,14 @@ module MojoMagick
   end
 
   def self.execute(command, *args)
-    # this suppress error messages to the console
-    # err_pipe = windows? ? "2>nul" : "2>/dev/null"
-
     execute = "#{command} #{args}"
-    out, outerr, status = Open3.capture3(command, *args)
+    out, outerr, status = Open3.capture3(command, *args.map(&:to_s))
     CommandStatus.new execute, out, outerr, status
   rescue Exception => e
     raise MojoError, "#{e.class}: #{e.message}"
   end
 
   def self.execute!(command, *args)
-    # this suppress error messages to the console
-    # err_pipe = windows? ? "2>nul" : "2>/dev/null"
     status = execute(command, *args)
     unless status.success?
       err_msg = "MojoMagick command failed: #{command}."

--- a/lib/mojo_magick/version.rb
+++ b/lib/mojo_magick/version.rb
@@ -1,3 +1,3 @@
 module MojoMagick
-  VERSION = "0.6.1"
+  VERSION = "0.6.0"
 end


### PR DESCRIPTION
Problem
-------

0.6.1 upgrade caused issues with parsing floats and other things.

Solution
--------

Map everything to strings before running the command

Bump back to 0.6.0 since it was never released