### PR TITLE
Fix `annotate` command

### DIFF
--- a/lib/mojo_magick/opt_builder.rb
+++ b/lib/mojo_magick/opt_builder.rb
@@ -27,10 +27,10 @@ module MojoMagick
     end
 
     # annotate takes non-standard args
-    def annotate(*args)
+    def annotate(*args, geometry: 0)
       @opts << "-annotate"
-      arguments = args.join.split
-      arguments.unshift "0" if arguments.length == 1
+      arguments = [args.join]
+      arguments.unshift geometry.to_s
       @opts << arguments
     end
 

--- a/test/opt_builder_test.rb
+++ b/test/opt_builder_test.rb
@@ -24,6 +24,16 @@ class MojoMagickOptBuilderTest < MiniTest::Test
     assert_equal %w[-annotate 5 it's], @builder.to_a
   end
 
+  def test_annotate_with_full_args
+    @builder.annotate "this thing", geometry: 3
+    assert_equal ["-annotate", "3", "this thing"], @builder.to_a
+  end
+
+  def test_annotate_with_full_array_args
+    @builder.annotate "this", "thing", geometry: 3
+    assert_equal ["-annotate", "3", "thisthing"], @builder.to_a
+  end
+
   def test_option_builder_with_blocks
     # Passing in basic commands produces a string
     b = MojoMagick::OptBuilder.new


### PR DESCRIPTION
Problem
-------

With the recent mod of how we escape/handle incoming arguments,
the annotate command wasn't properly working with multi word strings.

Solution
--------

Because `annotate` already takes a weird set of args, this PR changes
the annotate interface.  If you need to specify geometry, you can use

```
c.annotate 'the words', geometry: '+1+2'
```

If you never added geometry *and* you only used single word strings,
this should still work as designed.