### PR TITLE
Fix font fetch

### DIFF
--- a/lib/image_magick/fonts.rb
+++ b/lib/image_magick/fonts.rb
@@ -1,7 +1,7 @@
 module ImageMagick
   class Fonts
     def self.all
-      raw_fonts = MojoMagick::Commands.raw_command("identify", "-list", "font")
+      raw_fonts = MojoMagick::Commands.send(:execute, "identify", "-list", "font").return_value
       MojoMagick::Util::FontParser.new(raw_fonts).parse
     end
   end


### PR DESCRIPTION
Problem
-------

In some environments (CircleCI for example) `identify -list font`
returns exit code 1 which makes our fetch fail in those environments.

Solution
--------

Use a safe execute that does not raise and ignore the exit code - only
for that call