### PR TITLE
fix error message detection for imagemagick 7

### DIFF
--- a/test/mojo_magick_test.rb
+++ b/test/mojo_magick_test.rb
@@ -188,7 +188,7 @@ class MojoMagickTest < MiniTest::Test
   rescue MojoMagick::MojoFailed => e
     assert e.message.include?("unrecognized option"),
            "Unable to find ImageMagick commandline error in the message"
-    assert e.message.include?("convert.c/ConvertImageCommand"),
+    assert e.message =~ /(convert|deprecate)\.c\/ConvertImageCommand/,
            "Unable to find ImageMagick commandline error in the message"
   end
 


### PR DESCRIPTION
In imagemagick 7, the code of ConvertImageCommand is in the deprecate.c file. The test needs to be adapted to match the error message.